### PR TITLE
feat: collect logs via OTEL

### DIFF
--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -1,0 +1,59 @@
+// ##ddev-generated
+
+/**
+ * 'otelcol.receiver.otlp' accepts OTLP-formatted data over the network and forwards it to other otelcol.* components.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.receiver.otlp/
+ */
+otelcol.receiver.otlp "default" {
+  http {
+    endpoint="grafana-alloy:4318"
+  }
+
+  output {
+    logs = [otelcol.processor.batch.default.input]
+    metrics = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input]
+  }
+}
+
+/**
+ * 'otelcol.processor.batch' accepts telemetry data from other otelcol components and places them into batches.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.batch/
+ */
+otelcol.processor.batch "default" {
+  output {
+    logs = [otelcol.exporter.loki.default.input]
+    metrics = [otelcol.exporter.prometheus.default.input]
+    traces  = [otelcol.exporter.otlphttp.tempo.input]
+  }
+}
+
+/**
+ * 'otelcol.exporter.prometheus' accepts OTLP-formatted metrics from other otelcol components, converts metrics to Prometheus-formatted metrics, and forwards the resulting metrics to prometheus components.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.prometheus/
+ */
+otelcol.exporter.prometheus "default" {
+  forward_to = [prometheus.remote_write.default.receiver]
+}
+
+/**
+ * 'otelcol.exporter.loki' accepts OTLP-formatted logs from other otelcol components, converts them to Loki-formatted log entries, and forwards them to loki components.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.loki/
+ */
+otelcol.exporter.loki "default" {
+  forward_to = [loki.write.default.receiver]
+}
+
+/**
+ * 'telcol.exporter.otlphttp' accepts telemetry data from other otelcol components and writes them over the network using the OTLP HTTP protocol.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.otlphttp/
+ */
+otelcol.exporter.otlphttp "tempo" {
+    client {
+        endpoint = "http://grafana-tempo:4318"
+        tls {
+            insecure             = true
+            insecure_skip_verify = true
+        }
+    }
+}

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: site-metrics-cakephp
 
 project_files:
   - config.site-metrics-cakephp.yaml
+  - alloy/otelcol.alloy
 
 post_install_actions:
   - #ddev-description:Restart to activate PHP module

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -191,6 +191,8 @@ install_cakephp() {
   cp "$DIR/tests/testdata/log-demo.php" "${TESTDIR}/log-demo.php"
   run ddev exec php log-demo.php
   assert_success
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep 15
 
   # Grafana Loki uses Trace discovery through logs
   run ddev exec curl -s "${LOKI_SERVER}/loki/api/v1/query" --data-urlencode 'query=sum(rate({service_name="cakephp"}[1m])) by (level)'


### PR DESCRIPTION
## The Issue

The current implementation outputs OTEL to the console. 
However, we want to add integration with [ddev-site-metrics](https://github.com/tyler36/ddev-site-metrics)

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR update the Alloy workflow for otel collection, specifically for CakePHP.

Tests are included to confirm:

- Logs are consumed by Grafana Loki
- Traces are consume by Grafana Tempo

## Manual Testing Instructions

1. Install CakePHP
1. Install tyler36/ddev-site-metrics
1. Install this PR

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics-laravel/tarball/refs/pull/2/head
ddev restart
```

1. Access project to trigger trace
1. Confirm trace appears in Grafana (may take a moment depending on system resouces and activity)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
