### PR TITLE
patch `opentelemetry-auto-cakephp`

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: site-metrics-cakephp
 
 project_files:
   - config.site-metrics-cakephp.yaml
+  - pr-385.patch
   - alloy/otelcol.alloy
 
 post_install_actions:
@@ -12,6 +13,34 @@ post_install_actions:
   - ddev composer require open-telemetry/opentelemetry-auto-pdo open-telemetry/opentelemetry-auto-psr15 open-telemetry/opentelemetry-auto-psr18 --dev -n
   - ddev composer require open-telemetry/opentelemetry-auto-psr3 php-http/guzzle7-adapter --dev -n
   - ddev composer config allow-plugins.php-http/discovery true -n
+  - # Patch opentelemetry-auto-cakephp until #385 is merged
+  -  |
+    # Add patch manager
+    ddev composer config --no-plugins allow-plugins.cweagans/composer-patches true -n
+    ddev composer require cweagans/composer-patches -n
+    # Move patch
+    mkdir -p ../patches/
+    mv pr-385.patch ../patches/
+    # Define the patch JSON
+    PATCH_JSON='
+    {
+      "extra": {
+        "patches": {
+          "open-telemetry/opentelemetry-auto-cakephp": {
+            "Undefined array key 0": "patches/pr-385.patch"
+          }
+        }
+      }
+    }
+    '
+    # Merge the patch into composer.json
+    tmpfile=$(mktemp)
+    cd ..
+    ddev exec jq --argjson patch "$PATCH_JSON" '
+      .extra.patches["open-telemetry/opentelemetry-auto-cakephp"]["Undefined array key 0"] = "patches/pr-385.patch"
+    ' "composer.json" > "$tmpfile" && mv "$tmpfile" "composer.json"
+    echo "Patch added successfully to composer.json."
+    ddev composer install -n
   - #ddev-nodisplay
     #ddev-description:Set default environment variables
   - ddev dotenv set .ddev/.env.web --otel-php-autoload-enabled=true > /dev/null 2>&1

--- a/pr-385.patch
+++ b/pr-385.patch
@@ -1,0 +1,22 @@
+From c648903a723034b135eaec8af9e741276a36016d Mon Sep 17 00:00:00 2001
+From: tyler36 <7234392+tyler36@users.noreply.github.com>
+Date: Mon, 9 Jun 2025 12:58:35 +0900
+Subject: [PATCH] Fix: Handle null request in CakePHP Server::run hook
+
+---
+ src/Instrumentation/CakePHP/src/Hooks/Cake/Http/Server.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Instrumentation/CakePHP/src/Hooks/Cake/Http/Server.php b/src/Instrumentation/CakePHP/src/Hooks/Cake/Http/Server.php
+index a90fd38c..e62be337 100644
+--- a/src/Instrumentation/CakePHP/src/Hooks/Cake/Http/Server.php
++++ b/src/Instrumentation/CakePHP/src/Hooks/Cake/Http/Server.php
+@@ -26,7 +26,7 @@ public function instrument(): void
+             \Cake\Http\Server::class,
+             'run',
+             pre: function (\Cake\Http\Server $server, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+-                $request = $params[0];
++                $request = $params[0] ?? null;
+                 assert($request === null || $request instanceof ServerRequestInterface);
+ 
+                 $request = $this->buildSpan($request, $class, $function, $filename, $lineno);


### PR DESCRIPTION
## The Issue

CakePHP displays the following warning:

`Warning: Undefined array key 0`

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR applies a patch to fix the issue.
A PR was submitted to patch upstream. Once merged, this PR can be reverted.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics-laravel/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

https://github.com/open-telemetry/opentelemetry-php-contrib/pull/385
