### PR TITLE
remove 'docker-compose.cakephp-logs' if parent 'ddev-site-metrics' addon is not present

### DIFF
--- a/alloy/cakephp-logs.alloy
+++ b/alloy/cakephp-logs.alloy
@@ -1,0 +1,52 @@
+// ##ddev-generated
+
+/**
+ * This file contains the pipeline for CakePHP logs.
+ * We map the CakePHP path in a docker-compose file, then use "local.file_match" to read them.
+ *
+ * 'local.file_match' discovers files on the local filesystem using glob patterns and the doublestar library.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/local/local.file_match/
+ */
+local.file_match "cakephp_logs" {
+  path_targets = [{
+    "__path__" = "/var/log/cakephp/**/*.log",
+    "service_name" = "cakephp_logs",
+  }]
+  sync_period = "10s"
+}
+
+/**
+ * 'loki.source.file' reads log entries from files and forwards them to other loki.* components.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/loki/loki.source.file/
+ */
+loki.source.file "cakephp_logs" {
+  targets = local.file_match.cakephp_logs.targets
+  forward_to = [loki.process.cakephp_multiline_log.receiver]
+}
+
+/**
+ * Parses multiline CakePHP logs.
+ * CakePHP log entries typically start with a timestamp like: [2024-05-19 14:22:31]
+ * @See https://grafana.com/docs/alloy/latest/reference/components/loki/loki.process/
+ */
+loki.process "cakephp_multiline_log" {
+  // https://grafana.com/docs/alloy/latest/reference/components/loki/loki.process/#stagemultiline
+  stage.multiline {
+    firstline = "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
+    max_wait_time   = "3s"
+  }
+
+  // Explicitly extract timestamp from the line
+  stage.regex {
+    expression = "^(?P<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})"
+  }
+
+  stage.labels {
+    values = {
+      timestamp = "timestamp",
+    }
+  }
+
+
+  forward_to = [loki.write.default.receiver]
+}

--- a/docker-compose.cakephp-logs.yaml
+++ b/docker-compose.cakephp-logs.yaml
@@ -1,0 +1,7 @@
+##ddev-generated
+services:
+  # Map the default CakePHP logs folder into Grafana Alloy.
+  # Then we use 'alloy/cakephp-logs.alloy' to parse the file and send it for processing.
+  grafana-alloy:
+    volumes:
+      - ../logs/:/var/log/cakephp

--- a/install.yaml
+++ b/install.yaml
@@ -7,6 +7,11 @@ project_files:
   - alloy/otelcol.alloy
 
 post_install_actions:
+  - #ddev-description:Remove log bind if 'site-metrics' is not installed
+  - |
+    if ddev addon list --installed | grep -v ' site-metrics ' && grep -q '#ddev-generated' docker-compose.cakephp-logs.yaml; then
+      rm docker-compose.cakephp-logs.yaml
+    fi
   - #ddev-description:Restart to activate PHP module
   - ddev restart
   - #ddev-description:Add required composer packages

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,8 @@ name: site-metrics-cakephp
 
 project_files:
   - config.site-metrics-cakephp.yaml
+  - docker-compose.cakephp-logs.yaml
+  - alloy/cakephp-logs.alloy
   - alloy/otelcol.alloy
 
 post_install_actions:

--- a/install.yaml
+++ b/install.yaml
@@ -7,10 +7,16 @@ project_files:
   - alloy/otelcol.alloy
 
 post_install_actions:
-  - #ddev-description:Remove log bind if 'site-metrics' is not installed
+  -  #ddev-description:Remove log bind if 'site-metrics' is not installed
   - |
-    if ddev addon list --installed | grep -v ' site-metrics ' && grep -q '#ddev-generated' docker-compose.cakephp-logs.yaml; then
-      rm docker-compose.cakephp-logs.yaml
+    if grep -q '#ddev-generated' docker-compose.cakephp-logs.yaml; then
+      if (ddev addon list --installed | grep -q " site-metrics "); then
+        echo "Found 'site-metrics' addon so no cleanup required."
+      else
+        echo "We didn't find 'ddev-site-metrics' so we're not sure if you have the 'alloy' service install."
+        echo "We'll remove the file to prevent a startup error."
+        rm docker-compose.cakephp-logs.yaml
+      fi
     fi
   - #ddev-description:Restart to activate PHP module
   - ddev restart

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -200,7 +200,8 @@ install_cakephp() {
 @test "it can collect logs via local CakePHP log files" {
   set -eu -o pipefail
 
-  setup_project
+  install_cakephp
+  ddev addon get tyler36/ddev-site-metrics
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"


### PR DESCRIPTION
## The Issue

Exisiting logs are not captured, only logs created after instrumentation is added (aka install this addon).

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR adds a parse to read existing log files. These are save under the `cakephp_logs` service.

This may lead to duplication between parsing log file and intercepted logs.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics-laravel/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
