### PR TITLE
refactor: test should function without `tyler36/ddev-site-metrics`

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -56,11 +56,6 @@ teardown() {
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
-setup_project() {
-  install_cakephp
-  ddev addon get tyler36/ddev-site-metrics
-}
-
 install_cakephp() {
   ddev config --project-type=cakephp --docroot=webroot
   ddev start
@@ -70,7 +65,7 @@ install_cakephp() {
 @test "install from directory" {
   set -eu -o pipefail
 
-  setup_project
+  install_cakephp
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
@@ -84,7 +79,7 @@ install_cakephp() {
 @test "it can collect traces" {
   set -eu -o pipefail
 
-  setup_project
+  install_cakephp
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
@@ -111,7 +106,8 @@ install_cakephp() {
 @test "it can collect traces via OTEL" {
   set -eu -o pipefail
 
-  setup_project
+  install_cakephp
+  ddev addon get tyler36/ddev-site-metrics
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
@@ -145,7 +141,7 @@ install_cakephp() {
 @test "it can collect logs" {
   set -eu -o pipefail
 
-  setup_project
+  install_cakephp
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
@@ -168,7 +164,8 @@ install_cakephp() {
 @test "it can collect logs via OTEL" {
   set -eu -o pipefail
 
-  setup_project
+  install_cakephp
+  ddev addon get tyler36/ddev-site-metrics
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"


### PR DESCRIPTION
## The Issue

All the tests are tied to the `tyler36/ddev-site-metrics` service. While the use of that addon is encourage, we should not assume developers want to use it.
They may prefer to 

- roll their own
- redirect to online/cloud services
- use console output

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR removes `ddev-site-metrics` from the tests except where we explicitly want to confirm settings.
We still want to confirm settings work with the parent addon though.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics-laravel/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
