### PR TITLE
refactor: remove restart when telemetry is active

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -18,8 +18,15 @@ post_install_actions:
         rm docker-compose.cakephp-logs.yaml
       fi
     fi
-  - #ddev-description:Restart to activate PHP module
-  - ddev restart
+  - #ddev-description:Restart to activate PHP module, if required
+  - |
+    echo "Checking for PHP telemetry ..."
+    if ddev php --ri opentelemetry | grep -q "hooks => enabled"; then
+      echo "✅ PHP telemetry active"
+    else
+      echo "❌ PHP telemetry NOT active. Restarting to apply."
+      ddev restart
+    fi
   - #ddev-description:Add required composer packages
   - ddev composer require open-telemetry/sdk open-telemetry/opentelemetry-auto-cakephp open-telemetry/exporter-otlp --dev -n
   - ddev composer require open-telemetry/opentelemetry-auto-pdo open-telemetry/opentelemetry-auto-psr15 open-telemetry/opentelemetry-auto-psr18 --dev -n


### PR DESCRIPTION
## The Issue

This pull request addresses an issue where ddev was unnecessarily restarted during the installation process, even when the opentelemetry PHP module was already active.  This restart significantly increased the installation time for users who already had the module enabled.

The problem was that the `ddev restart` command was unconditionally executed after the removal of the docker-compose file.  This PR introduces a check to verify if the `opentelemetry` module is enabled in PHP before triggering a restart. The restart is only initiated if the `opentelemetry` module is not active.

## How This PR Solves The Issue

This PR checks to see if the opentelemetry PHP module is installed and enabled. 

If not, it restarts DDEV to active it.
If so, it skips the restart and continues.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics-laravel/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

1.  **Scenario 1:  `opentelemetry` module NOT active:**

    *   Ensure that the `opentelemetry` module is NOT enabled in your ddev environment.  You can remove it by commenting out the relevant lines in your `php.ini` file, or use `ddev xdebug off` if you are using xdebug to manage other php modules.
    *   Run `ddev get julianxhokaxhiu/ddev-opentelemetry`.
    *   Observe the output. You should see the message `❌ PHP telemetry NOT active. Restarting to apply.` and a `ddev restart` command should be executed.
    *   After the installation completes, verify that the `opentelemetry` module is now enabled in PHP by running `ddev php --ri opentelemetry`. It should show `hooks => enabled`.

2.  **Scenario 2: `opentelemetry` module already active:**

    *   Ensure that the `opentelemetry` module is enabled in your ddev environment, in your `php.ini` file.
    *   Run `ddev get julianxhokaxhiu/ddev-opentelemetry`.
    *   Observe the output. You should see the message `✅ PHP telemetry active` and the `ddev restart` command should NOT be executed.
    *   Verify that the `opentelemetry` module remains enabled in PHP by running `ddev php --ri opentelemetry`. It should show `hooks => enabled`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
