### PR TITLE
feat: default to GRPC protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ OTEL_PHP_AUTOLOAD_ENABLED="false"
 
 ```conf
 OTEL_TRACES_EXPORTER="otlp"
-OTEL_EXPORTER_OTLP_ENDPOINT=http://grafana-alloy:4318
+OTEL_EXPORTER_OTLP_ENDPOINT=http://grafana-alloy:4317
 ```
 
 ## Configuration

--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -5,6 +5,9 @@
  * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.receiver.otlp/
  */
 otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint="grafana-alloy:4317"
+  }
   http {
     endpoint="grafana-alloy:4318"
   }
@@ -24,7 +27,7 @@ otelcol.processor.batch "default" {
   output {
     logs = [otelcol.exporter.loki.default.input]
     metrics = [otelcol.exporter.prometheus.default.input]
-    traces  = [otelcol.exporter.otlphttp.tempo.input]
+    traces  = [otelcol.exporter.otlp.tempo.input]
   }
 }
 
@@ -42,6 +45,20 @@ otelcol.exporter.prometheus "default" {
  */
 otelcol.exporter.loki "default" {
   forward_to = [loki.write.default.receiver]
+}
+
+/**
+ * 'otelcol.exporter.otlp' accepts telemetry data from other otelcol components and writes them over the network using the OTLP gRPC protocol.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.otlp/
+ */
+otelcol.exporter.otlp "tempo" {
+    client {
+        endpoint = "grafana-tempo:4317"
+        tls {
+            insecure             = true
+            insecure_skip_verify = true
+        }
+    }
 }
 
 /**

--- a/config.site-metrics-cakephp.yaml
+++ b/config.site-metrics-cakephp.yaml
@@ -1,2 +1,2 @@
 ##ddev-generated
-webimage_extra_packages: ["php${DDEV_PHP_VERSION}-opentelemetry"]
+webimage_extra_packages: ["php${DDEV_PHP_VERSION}-opentelemetry", "php${DDEV_PHP_VERSION}-grpc"]

--- a/install.yaml
+++ b/install.yaml
@@ -28,7 +28,7 @@ post_install_actions:
       ddev restart
     fi
   - #ddev-description:Add required composer packages
-  - ddev composer require open-telemetry/sdk open-telemetry/opentelemetry-auto-cakephp open-telemetry/exporter-otlp --dev -n
+  - ddev composer require open-telemetry/sdk open-telemetry/opentelemetry-auto-cakephp open-telemetry/exporter-otlp open-telemetry/transport-grpc --dev -n
   - ddev composer require open-telemetry/opentelemetry-auto-pdo open-telemetry/opentelemetry-auto-psr15 open-telemetry/opentelemetry-auto-psr18 --dev -n
   - ddev composer require open-telemetry/opentelemetry-auto-psr3 php-http/guzzle7-adapter --dev -n
   - ddev composer config allow-plugins.php-http/discovery true -n
@@ -40,6 +40,7 @@ post_install_actions:
   - ddev dotenv set .ddev/.env.web --otel-logs-exporter="otlp" > /dev/null 2>&1
   - ddev dotenv set .ddev/.env.web --otel-php-psr3-mode="export" > /dev/null 2>&1
   - ddev dotenv set .ddev/.env.web --otel-traces-exporter="otlp" > /dev/null 2>&1
-  - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-endpoint="http://grafana-alloy:4318" > /dev/null 2>&1
+  - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-endpoint="http://grafana-alloy:4317" > /dev/null 2>&1
+  - ddev dotenv set .ddev/.env.web --otel-exporter-otlp-protocol="grpc" > /dev/null 2>&1
 
 ddev_version_constraint: '>= v1.24.3'


### PR DESCRIPTION
## The Issue

The previous configuration relied on the OTLP HTTP exporter, which was not effectively transmitting traces to Tempo. Additionally, the required gRPC extension for PHP was missing, preventing the application from properly utilizing gRPC for OTLP trace exports.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR ensure that the application utilizes gRPC for OTLP trace exports, with the correct endpoint and protocol, enabling successful transmission of traces to Tempo.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics-laravel/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
